### PR TITLE
Remove the old alias entry from jbang and rename the alias

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -99,7 +99,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           SNAPSHOT_URL="https://github.com/${{ github.repository }}/releases/download/early-access/rewrite-client-${{ needs.precheck.outputs.VERSION }}-runner.jar"
-          jq --arg url "$SNAPSHOT_URL" '.aliases.openrewrite."script-ref" = $url' jbang-catalog.json > tmp.json && mv tmp.json jbang-catalog.json
+          jq --arg url "$SNAPSHOT_URL" '.aliases.rewrite."script-ref" = $url' jbang-catalog.json > tmp.json && mv tmp.json jbang-catalog.json
 
       - name: Commit the changes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           VERSION=${{ github.event.inputs.version }}
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/download/$VERSION/rewrite-client-$VERSION-runner.jar"
           echo "Updating catalog with new URL: ${RELEASE_URL}"
-          jq --arg url "$RELEASE_URL" '.aliases.openrewrite["script-ref"] = $url' jbang-catalog.json > temp.json && mv temp.json jbang-catalog.json
+          jq --arg url "$RELEASE_URL" '.aliases.rewrite["script-ref"] = $url' jbang-catalog.json > temp.json && mv temp.json jbang-catalog.json
 
       - name: Commit the changes
         run: |

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -4,9 +4,6 @@
     "rewrite": {
       "description": "Quarkus OpenRewrite client to execute recipes",
       "script-ref": "https://github.com/snowdrop/rewrite-client/releases/download/early-access/rewrite-client-0.2.11-SNAPSHOT-runner.jar"
-    },
-    "openrewrite": {
-      "script-ref": "https://github.com/snowdrop/rewrite-client/releases/download/early-access/rewrite-client-0.2.11-SNAPSHOT-runner.jar"
     }
   },
   "templates": {}


### PR DESCRIPTION
- Remove the old alias entry from jbang catalog and rename the alias to be changed during the execution of the github jobs