### PR TITLE
fix: bumped mima.version and maven.version.All resolver artifacts are…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,16 @@
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.release>21</maven.compiler.release>
 
-        <!-- These two should be kept in lockstep (MIMA 2.4.38 = Maven 3.9.11 + Resolver 1.9.24) -->
-        <mima.version>2.4.38</mima.version>
-        <maven.version>3.9.11</maven.version>
+        <!-- These two should be kept in lockstep (MIMA 2.4.39 = Maven 3.9.12 + Resolver 1.9.25) -->
+        <mima.version>2.4.39</mima.version>
+        <maven.version>3.9.12</maven.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.29.4</quarkus.platform.version>
+        <quarkus.platform.version>3.32.2</quarkus.platform.version>
 
         <openrewrite-bom.version>8.74.3</openrewrite-bom.version>
         <openrewrite-rewrite-polyglot.version>2.9.6</openrewrite-rewrite-polyglot.version>

--- a/service/dependency-reduced-pom.xml
+++ b/service/dependency-reduced-pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
-      <version>3.29.4</version>
+      <version>3.32.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -51,30 +51,8 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
-      <version>3.29.4</version>
+      <version>3.32.2</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>quarkus-bootstrap-core</artifactId>
-          <groupId>io.quarkus</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>quarkus-test-common</artifactId>
-          <groupId>io.quarkus</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>quarkus-junit5-config</artifactId>
-          <groupId>io.quarkus</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>junit-jupiter</artifactId>
-          <groupId>org.junit.jupiter</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>quarkus-core</artifactId>
-          <groupId>io.quarkus</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -92,7 +70,7 @@
   <properties>
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
-    <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 </project>


### PR DESCRIPTION
After upgrading Quarkus to 3.32.2, the Quarkus BOM started managing maven-core:3.9.12, which pulls in `maven-resolver-impl:1.9.25`. That version hardcodes `gaecv` as its default name mapper. However, mima 2.4.38 was still pulling `maven-resolver-supplier:1.9.24`, which only registers 5 name mappers (static, gav, discriminating, file-gav, file-hgav), not gaecv.